### PR TITLE
listenMessage 불리지 않는 문제 해결

### DIFF
--- a/ios/Classes/FlutterPagecallView.swift
+++ b/ios/Classes/FlutterPagecallView.swift
@@ -21,7 +21,7 @@ public class FlutterPagecallView: NSObject, FlutterPlatformView {
     }
 }
 
-class FlutterEmbedView : UIView {
+class FlutterEmbedView: UIView, PagecallDelegate {
     let pagecallWebView = PagecallWebView()
     
     private var channel: FlutterMethodChannel?
@@ -36,15 +36,13 @@ class FlutterEmbedView : UIView {
         
         initMethodChannel()
         initParams(creationParams)
-        
+
+        pagecallWebView.delegate = self
+
         Task {
             await invalidateWebsideDataIncludingAccessToken()
-            
-            let _ = pagecallWebView.load(roomId: roomId!, mode: mode!, queryItems: [URLQueryItem.init(name: "access_token", value: accessToken)])
-            
-            let _ = self.pagecallWebView.listenMessage { message in
-                self.channel?.invokeMethod("onMessageReceived", arguments: message)
-            }
+
+            _ = pagecallWebView.load(roomId: roomId!, mode: mode!, queryItems: [URLQueryItem.init(name: "access_token", value: accessToken)])
         }
         
         self.addSubview(pagecallWebView)
@@ -121,5 +119,14 @@ class FlutterEmbedView : UIView {
                                        width: self.frame.width,
                                        height: self.frame.height)
         super.layoutSubviews()
+    }
+
+    // MARK: PagecallDelegate
+    func pagecallDidTerminate(_ view: Pagecall.PagecallWebView, reason: Pagecall.TerminationReason) {
+        // Noop
+    }
+
+    func pagecallDidReceive(_ view: PagecallWebView, message: String) {
+        self.channel?.invokeMethod("onMessageReceived", arguments: message)
     }
 }


### PR DESCRIPTION
`listenMessage` 는 페이지콜 스크립트 로드를 완료한 후에 불러야만 동작합니다!
이런 복잡성들을 내부화하고자 페이지콜에서 나오는 이벤트들은 모두 `PagecallDelegate`를 통해서 받기를 바라는 의도가 https://github.com/pagecall/pagecall-ios-sdk/pull/40 에 포함되어 있었습니다
RN SDK에도 이대로 적용이 안되어있으나 pagecallDidLoad 안에서 호출해주어서 문제가 없던 상황이었습니다
번거롭게 해드려 죄송합니다! 확인하시면 머지하셔도 되고 복사해서 차용하셔도 무방합니다~!