### PR TITLE
feat: Improved sample app to receive information for room access

### DIFF
--- a/android/src/main/kotlin/com/pagecall/pagecall_flutter/FlutterPagecallView.kt
+++ b/android/src/main/kotlin/com/pagecall/pagecall_flutter/FlutterPagecallView.kt
@@ -12,6 +12,14 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.platform.PlatformView
 
+fun String.toMap(): Map<String, String> {
+    return this.split("&")
+        .map {
+            val pair = it.split("=")
+            pair[0] to pair[1]
+        }
+        .toMap()
+}
 class FlutterPagecallView(
     context: Context,
     private val channel: MethodChannel,
@@ -23,6 +31,7 @@ class FlutterPagecallView(
     private var mode: String? = null
     private var roomId: String? = null
     private var accessToken: String? = null
+    private var queryParams: String? = null
     private var debuggable: Boolean = false
 
     init {
@@ -72,12 +81,17 @@ class FlutterPagecallView(
             accessToken = params.getValue("accessToken")?.toString()
         }
 
+        if(params.containsKey("queryParams")) {
+            queryParams = params.getValue("queryParams")?.toString()
+        }
+
         if (params.containsKey("debuggable")) {
             debuggable = params.getOrDefault("debuggable", false) as Boolean
         }
     }
 
     private fun loadPage() {
+        val queryMap = queryParams?.toMap()
         val url = Uri.parse("https://app.pagecall.com").buildUpon()
             .path(mode)
             .apply {
@@ -88,6 +102,11 @@ class FlutterPagecallView(
             .apply {
                 if (roomId != null) {
                     appendQueryParameter("access_token", accessToken)
+                }
+            }
+            .apply {
+                queryMap?.forEach { (key, value) ->
+                    appendQueryParameter(key, value)
                 }
             }
             .build()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,52 +1,115 @@
-import 'dart:async';
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pagecall_flutter/pagecall_flutter.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 
-Future main() async {
-  WidgetsFlutterBinding.ensureInitialized();
+void main() => runApp(const MyApp());
 
-  runApp(const MyApp());
-}
-
-class MyApp extends StatefulWidget {
+class MyApp extends StatelessWidget {
   const MyApp({super.key});
-
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  late final TextEditingController _textFieldController;
-  PagecallViewController? _pagecallViewController;
-
-  @override
-  void initState() {
-    super.initState();
-
-    _textFieldController = TextEditingController();
-  }
-
-  @override
-  void dispose() {
-    _textFieldController.dispose();
-
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('PagecallView example app'),
-        ),
-        body: Column(
+      title: 'Text Transfer',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const FirstScreen(),
+    );
+  }
+}
+
+class FirstScreen extends StatefulWidget {
+  const FirstScreen({super.key});
+
+  @override
+  State<FirstScreen> createState() => _FirstScreenState();
+}
+
+class _FirstScreenState extends State<FirstScreen> {
+  TextEditingController roomIdFieldController = TextEditingController();
+  TextEditingController accessTokenFieldController = TextEditingController();
+  TextEditingController queryParamsFieldController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Room Setting'),
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Column(children: [
+            TextField(
+              controller: roomIdFieldController,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.all(8.0),
+                hintText: 'Enter Room Id',
+              ),
+            ),
+            TextField(
+              controller: accessTokenFieldController,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.all(8.0),
+                hintText: 'Enter Access Token',
+              ),
+            ),
+            TextField(
+              controller: queryParamsFieldController,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.all(8.0),
+                hintText: 'Enter Query Params (Optional, a=1&b=2&c=3)',
+              ),
+            ),
+          ],),
+          ElevatedButton(
+            child: const Text('Enter Room'),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => SecondScreen(
+                    roomId: roomIdFieldController.text, 
+                    accessToken: accessTokenFieldController.text, 
+                    queryParams: queryParamsFieldController.text
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class SecondScreen extends StatefulWidget {
+  final String roomId;
+  final String accessToken;
+  final String queryParams;
+
+  const SecondScreen({super.key, required this.roomId, this.accessToken = '', this.queryParams = ''});
+
+  @override
+  State<SecondScreen> createState() => _SecondScreenState();
+}
+
+class _SecondScreenState extends State<SecondScreen> {
+  final TextEditingController messageFieldController = TextEditingController();
+
+  PagecallViewController? pagecallViewController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pagecall Room'),
+      ),
+      body: Column(
           children: [
             TextField(
-              controller: _textFieldController,
+              controller: messageFieldController,
               decoration: const InputDecoration(
                 contentPadding: EdgeInsets.all(8.0),
                 hintText: "Submit to invoke sendMessage",
@@ -57,12 +120,11 @@ class _MyAppState extends State<MyApp> {
             Expanded(
               child: PagecallView(
                 mode: "meet",
-                roomId: "6486b3db6d4b09eaf7a6f456",
-                accessToken: Platform.isAndroid
-                    ? "3UXS_RTalT6VCIs5AuSnE-8yHIocRgny"
-                    : "cd_FQbSbZAr8LMcp4Zd4GbDAbDbKpT7R",
+                roomId: widget.roomId,
+                accessToken: widget.accessToken,
+                queryParams: widget.queryParams,
                 onViewCreated: (controller) {
-                  _pagecallViewController = controller;
+                  pagecallViewController = controller;
                 },
                 onMessage: (message) {
                   debugPrint('Received message=$message');
@@ -81,14 +143,13 @@ class _MyAppState extends State<MyApp> {
             ),
           ],
         ),
-      ),
     );
   }
 
   void _invokeSendMessage(String message) {
     debugPrint('invoking with message=$message');
 
-    _pagecallViewController?.sendMessage(message);
-    _textFieldController.clear();
+    pagecallViewController?.sendMessage(message);
+    messageFieldController.clear();
   }
 }

--- a/lib/pagecall_flutter.dart
+++ b/lib/pagecall_flutter.dart
@@ -15,6 +15,8 @@ class PagecallView extends StatelessWidget {
 
   final String? accessToken;
 
+  final String? queryParams;
+
   final void Function(PagecallViewController controller)? onViewCreated;
 
   final void Function()? onLoaded;
@@ -30,6 +32,7 @@ class PagecallView extends StatelessWidget {
     this.mode,
     this.roomId,
     this.accessToken,
+    this.queryParams,
     this.onViewCreated,
     this.onLoaded,
     this.onMessage,
@@ -69,6 +72,7 @@ class PagecallView extends StatelessWidget {
         mode: mode,
         roomId: roomId,
         accessToken: accessToken,
+        queryParams: queryParams,
         debuggable: debuggable,
       ),
       viewType: viewType,
@@ -92,12 +96,15 @@ class CreationParams {
 
   final String? accessToken;
 
+  final String? queryParams;
+
   final bool debuggable;
 
   CreationParams({
     this.mode,
     this.roomId,
     this.accessToken,
+    this.queryParams,
     this.debuggable = false,
   });
 
@@ -106,6 +113,7 @@ class CreationParams {
       "mode": mode,
       "roomId": roomId,
       "accessToken": accessToken,
+      "queryParams": queryParams,
       "debuggable": debuggable
     };
   }


### PR DESCRIPTION
1. Flutter PagecallView가 queryParams(string)을 받을 수 있습니다.
2. 샘플앱에서 roomId, accessToken, queryParam을 사용자로부터 받은 후 그것으로 페이지콜 룸에 입장할 수 있습니다.

<img width="439" alt="image" src="https://github.com/pagecall/flutter-pagecall/assets/19991994/c9f01b04-5de5-4b5f-b370-18fff59a5964">
<img width="442" alt="image" src="https://github.com/pagecall/flutter-pagecall/assets/19991994/d2cb633d-6aa1-4a57-af41-376a0ca1b3e1">
