### PR TITLE
fix: handle dispose

### DIFF
--- a/android/src/main/kotlin/com/pagecall/pagecall_flutter/FlutterPagecallView.kt
+++ b/android/src/main/kotlin/com/pagecall/pagecall_flutter/FlutterPagecallView.kt
@@ -125,6 +125,10 @@ class FlutterPagecallView(
                 message?.let { pagecallWebView.sendMessage(it) }
                 result.success(null)
             }
+            "dispose" -> {
+                dispose()
+                result.success(null)
+            }
         }
     }
 

--- a/android/src/main/kotlin/com/pagecall/pagecall_flutter/FlutterPagecallView.kt
+++ b/android/src/main/kotlin/com/pagecall/pagecall_flutter/FlutterPagecallView.kt
@@ -14,9 +14,9 @@ import io.flutter.plugin.platform.PlatformView
 
 fun String.toMap(): Map<String, String> {
     return this.split("&")
-        .map {
+        .mapNotNull {
             val pair = it.split("=")
-            pair[0] to pair[1]
+            if (pair.size == 2) pair[0] to pair[1] else null
         }
         .toMap()
 }

--- a/ios/Classes/FlutterPagecallView.swift
+++ b/ios/Classes/FlutterPagecallView.swift
@@ -93,6 +93,12 @@ class FlutterEmbedView: UIView, PagecallDelegate {
             }
             result(nil)
             break
+        case "dispose":
+            DispatchQueue.main.async {
+                self.dispose()
+            }
+            result(nil)
+            break;
         default:
             result(FlutterMethodNotImplemented)
             break
@@ -158,5 +164,11 @@ class FlutterEmbedView: UIView, PagecallDelegate {
     
     func pagecallDidReceive(_ view: PagecallWebView, message: String) {
         self.channel?.invokeMethod("onMessage", arguments: message)
+    }
+    
+    private func dispose() {
+        self.channel?.setMethodCallHandler(nil)
+        self.pagecallWebView.removeFromSuperview()
+        self.pagecallWebView.delegate = nil
     }
 }

--- a/ios/Classes/FlutterPagecallView.swift
+++ b/ios/Classes/FlutterPagecallView.swift
@@ -4,8 +4,9 @@ import WebKit
 import Pagecall
 
 func stringToQueryItems(_ queryString: String) -> [URLQueryItem] {
-    return queryString.components(separatedBy: "&").map { component in
+    return queryString.components(separatedBy: "&").compactMap { component in
         let keyValuePair = component.components(separatedBy: "=")
+        guard keyValuePair.count == 2 else { return nil }
         return URLQueryItem(name: keyValuePair[0], value: keyValuePair[1])
     }
 }

--- a/lib/pagecall_flutter.dart
+++ b/lib/pagecall_flutter.dart
@@ -6,9 +6,7 @@ import 'package:pagecall_flutter/src/android_pagecallview.dart';
 import 'package:pagecall_flutter/src/cupertino_pagecallview.dart';
 
 //ignore: must_be_immutable
-class PagecallView extends StatelessWidget {
-  static const String viewType = 'com.pagecall/pagecall_flutter';
-
+class PagecallView extends StatefulWidget {
   final String? mode;
 
   final String? roomId;
@@ -25,9 +23,7 @@ class PagecallView extends StatelessWidget {
 
   final bool debuggable;
 
-  late PagecallViewController _controller;
-
-  PagecallView({
+  const PagecallView({
     Key? key,
     this.mode,
     this.roomId,
@@ -39,6 +35,17 @@ class PagecallView extends StatelessWidget {
     this.onTerminated,
     this.debuggable = false,
   }) : super(key: key);
+
+
+  @override
+  // ignore: library_private_types_in_public_api
+  _PagecallViewState createState() => _PagecallViewState();
+}
+class _PagecallViewState extends State<PagecallView> {
+  static const String viewType = 'com.pagecall/pagecall_flutter';
+
+
+  late PagecallViewController _controller;
 
   static PlatformPagecallView? _platform;
 
@@ -69,11 +76,11 @@ class PagecallView extends StatelessWidget {
     return platform!.build(
       context: context,
       creationParams: CreationParams(
-        mode: mode,
-        roomId: roomId,
-        accessToken: accessToken,
-        queryParams: queryParams,
-        debuggable: debuggable,
+        mode: widget.mode,
+        roomId: widget.roomId,
+        accessToken: widget.accessToken,
+        queryParams: widget.queryParams,
+        debuggable: widget.debuggable,
       ),
       viewType: viewType,
       onPlatformViewCreated: _onPlatformViewCreated,
@@ -81,11 +88,17 @@ class PagecallView extends StatelessWidget {
   }
 
   void _onPlatformViewCreated(int id) {
-    _controller = PagecallViewController(id, this);
+    _controller = PagecallViewController(id, widget);
 
-    if (onViewCreated != null) {
-      onViewCreated!(_controller);
+    if (widget.onViewCreated != null) {
+      widget.onViewCreated!(_controller);
     }
+  }
+
+  @override
+  void dispose() {
+    _controller._channel.invokeMethod("dispose");
+    super.dispose();
   }
 }
 


### PR DESCRIPTION
- PagecallView(flutter)가 dispose될 때 PagecallView(native)도 dispose되도록 합니다.

사소한 개선
- invalid query string을 사용자로부터 받더라도 문제 없도록 합니다.