### PR TITLE
refactor: change package name pagecall_flutter -> flutter_pagecall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
 ## 1.0.0
-* The first version
-
-## 1.0.1
 * Update iOS SDK (to 0.0.15)
 * Update Android SDK (to 0.0.19)
 * handle Pagecall events (onLoaded, onMessage, onTerminated)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the official Pagecall Flutter SDK developed and maintained by Pagecall I
 In the `dependencies:` section of your `pubspec.yaml`, add the following line:
 ```yaml
 dependencies:
-  pagecall_flutter: <latest_version>
+  flutter_pagecall: <latest_version>
 ```
 
 For Android build, generate Github access token with `read:packages` scope on Github profile setting, then set `GITHUB_USERNAME` and `GITHUB_TOKEN` for your environment variables or put these as properties of the Android root project when running your app.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-group 'com.pagecall.pagecall_flutter'
+group 'com.pagecall.flutter_pagecall'
 version '1.0-SNAPSHOT'
 
 buildscript {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'pagecall_flutter'
+rootProject.name = 'flutter_pagecall'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pagecall.pagecall_flutter">
+    package="com.pagecall.flutter_pagecall">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/android/src/main/kotlin/com/pagecall/flutter_pagecall/FlutterPagecallView.kt
+++ b/android/src/main/kotlin/com/pagecall/flutter_pagecall/FlutterPagecallView.kt
@@ -1,4 +1,4 @@
-package com.pagecall.pagecall_flutter
+package com.pagecall.flutter_pagecall
 
 import android.content.Context
 import android.net.Uri

--- a/android/src/main/kotlin/com/pagecall/flutter_pagecall/FlutterPagecallViewFactory.kt
+++ b/android/src/main/kotlin/com/pagecall/flutter_pagecall/FlutterPagecallViewFactory.kt
@@ -1,4 +1,4 @@
-package com.pagecall.pagecall_flutter
+package com.pagecall.flutter_pagecall
 
 import android.content.Context
 import io.flutter.plugin.common.BinaryMessenger
@@ -13,7 +13,7 @@ class FlutterPagecallViewFactory(
 ) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
 
     override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
-        val channel = MethodChannel(messenger, "com.pagecall/pagecall_flutter$${viewId}")
+        val channel = MethodChannel(messenger, "com.pagecall/flutter_pagecall$${viewId}")
 
         return FlutterPagecallView(context, channel, args as Map<String, Any>)
     }

--- a/android/src/main/kotlin/com/pagecall/flutter_pagecall/PagecallFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pagecall/flutter_pagecall/PagecallFlutterPlugin.kt
@@ -1,4 +1,4 @@
-package com.pagecall.pagecall_flutter
+package com.pagecall.flutter_pagecall
 
 import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -10,7 +10,7 @@ class PagecallFlutterPlugin : FlutterPlugin {
         val registry = flutterPluginBinding.platformViewRegistry
 
         registry.registerViewFactory(
-            "com.pagecall/pagecall_flutter",
+            "com.pagecall/flutter_pagecall",
             FlutterPagecallViewFactory(messenger)
         )
     }

--- a/android/src/test/kotlin/com/pagecall/pagecall_flutter/PagecallFlutterPluginTest.kt
+++ b/android/src/test/kotlin/com/pagecall/pagecall_flutter/PagecallFlutterPluginTest.kt
@@ -1,4 +1,4 @@
-package com.pagecall.pagecall_flutter
+package com.pagecall.flutter_pagecall
 
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
-# pagecall_flutter_example
+# flutter_pagecall_example
 
-Demonstrates how to use the pagecall_flutter plugin.
+Demonstrates how to use the flutter_pagecall plugin.
 
 ## Getting Started
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    namespace "com.pagecall.pagecall_flutter_example"
+    namespace "com.pagecall.flutter_pagecall_example"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
@@ -45,7 +45,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.pagecall.pagecall_flutter_example"
+        applicationId "com.pagecall.flutter_pagecall_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 24

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="pagecall_flutter_example"
+        android:label="flutter_pagecall_example"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/android/app/src/main/kotlin/com/pagecall/pagecall_flutter_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/pagecall/pagecall_flutter_example/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.pagecall.pagecall_flutter_example
+package com.pagecall.flutter_pagecall_example
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_pagecall (0.0.1):
+    - Flutter
+    - Pagecall (= 0.0.15)
   - fluttertoast (0.0.2):
     - Flutter
     - Toast
   - integration_test (0.0.1):
     - Flutter
   - Pagecall (0.0.15)
-  - pagecall_flutter (0.0.1):
-    - Flutter
-    - Pagecall (= 0.0.15)
   - Toast (4.0.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_pagecall (from `.symlinks/plugins/flutter_pagecall/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
-  - pagecall_flutter (from `.symlinks/plugins/pagecall_flutter/ios`)
 
 SPEC REPOS:
   trunk:
@@ -25,19 +25,19 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_pagecall:
+    :path: ".symlinks/plugins/flutter_pagecall/ios"
   fluttertoast:
     :path: ".symlinks/plugins/fluttertoast/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
-  pagecall_flutter:
-    :path: ".symlinks/plugins/pagecall_flutter/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  flutter_pagecall: 0c5d2d31e54bee88c4798e81ad916a5349ff786e
   fluttertoast: fafc4fa4d01a6a9e4f772ecd190ffa525e9e2d9c
   integration_test: 13825b8a9334a850581300559b8839134b124670
   Pagecall: 3488f4fdbbd31e4730bf8ad0a829379a0b5c496f
-  pagecall_flutter: 220516000a7ec9d267c3422d1c870ff07f0a4e3e
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
 PODFILE CHECKSUM: 1959d098c91d8a792531a723c4a9d7e9f6a01e38

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>pagecall_flutter_example</string>
+	<string>flutter_pagecall_example</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -2,7 +2,7 @@ import Flutter
 import UIKit
 import XCTest
 
-@testable import pagecall_flutter
+@testable import flutter_pagecall
 
 // This demonstrates a simple unit test of the Swift portion of this plugin's implementation.
 //

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:pagecall_flutter/pagecall_flutter.dart';
+import 'package:flutter_pagecall/flutter_pagecall.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 
 void main() => runApp(const MyApp());

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,10 +79,17 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
+  flutter_pagecall:
+    dependency: "direct main"
+    description:
+      path: ".."
+      relative: true
+    source: path
+    version: "1.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -151,13 +158,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  pagecall_flutter:
-    dependency: "direct main"
-    description:
-      path: ".."
-      relative: true
-    source: path
-    version: "1.0.1"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,5 @@
-name: pagecall_flutter_example
-description: Demonstrates how to use the pagecall_flutter plugin.
+name: flutter_pagecall_example
+description: Demonstrates how to use the flutter_pagecall plugin.
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
@@ -17,9 +17,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pagecall_flutter:
+  flutter_pagecall:
     # When depending on this package from a real application you should use:
-    #   pagecall_flutter: ^x.y.z
+    #   flutter_pagecall: ^x.y.z
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:pagecall_flutter_example/main.dart';
+import 'package:flutter_pagecall_example/main.dart';
 
 void main() {
   testWidgets('Verify Platform version', (WidgetTester tester) async {

--- a/ios/Classes/FlutterPagecallViewFactory.swift
+++ b/ios/Classes/FlutterPagecallViewFactory.swift
@@ -10,7 +10,7 @@ public class FlutterPagecallViewFactory: NSObject, FlutterPlatformViewFactory {
     }
     
     public func create(withFrame frame: CGRect, viewIdentifier viewId: Int64, arguments args: Any?) -> FlutterPlatformView {
-        let channel = FlutterMethodChannel(name: "com.pagecall/pagecall_flutter$\(viewId)", binaryMessenger: messenger)
+        let channel = FlutterMethodChannel(name: "com.pagecall/flutter_pagecall$\(viewId)", binaryMessenger: messenger)
         
         return FlutterPagecallView(
             frame: frame,

--- a/ios/Classes/PagecallFlutterPlugin.swift
+++ b/ios/Classes/PagecallFlutterPlugin.swift
@@ -5,6 +5,6 @@ public class PagecallFlutterPlugin: NSObject, FlutterPlugin {
       let messenger = registrar.messenger()
       let factory = FlutterPagecallViewFactory(messenger: messenger)
       
-      registrar.register(factory, withId: "com.pagecall/pagecall_flutter")
+      registrar.register(factory, withId: "com.pagecall/flutter_pagecall")
   }
 }

--- a/ios/flutter_pagecall.podspec
+++ b/ios/flutter_pagecall.podspec
@@ -1,9 +1,9 @@
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint pagecall_flutter.podspec` to validate before publishing.
+# Run `pod lib lint flutter_pagecall.podspec` to validate before publishing.
 #
 Pod::Spec.new do |s|
-  s.name             = 'pagecall_flutter'
+  s.name             = 'flutter_pagecall'
   s.version          = '0.0.1'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC

--- a/lib/flutter_pagecall.dart
+++ b/lib/flutter_pagecall.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:pagecall_flutter/platform_interface.dart';
-import 'package:pagecall_flutter/src/android_pagecallview.dart';
-import 'package:pagecall_flutter/src/cupertino_pagecallview.dart';
+import 'package:flutter_pagecall/platform_interface.dart';
+import 'package:flutter_pagecall/src/android_pagecallview.dart';
+import 'package:flutter_pagecall/src/cupertino_pagecallview.dart';
 
 //ignore: must_be_immutable
 class PagecallView extends StatefulWidget {
@@ -42,7 +42,7 @@ class PagecallView extends StatefulWidget {
   _PagecallViewState createState() => _PagecallViewState();
 }
 class _PagecallViewState extends State<PagecallView> {
-  static const String viewType = 'com.pagecall/pagecall_flutter';
+  static const String viewType = 'com.pagecall/flutter_pagecall';
 
 
   late PagecallViewController _controller;
@@ -139,7 +139,7 @@ class PagecallViewController {
 
   PagecallViewController(dynamic id, PagecallView pagecallView) {
     _id = id;
-    String channelName = "com.pagecall/pagecall_flutter\$$_id";
+    String channelName = "com.pagecall/flutter_pagecall\$$_id";
 
     _channel = MethodChannel(channelName);
     _channel.setMethodCallHandler(handleMethod);

--- a/lib/platform_interface.dart
+++ b/lib/platform_interface.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:pagecall_flutter/pagecall_flutter.dart';
+import 'package:flutter_pagecall/flutter_pagecall.dart';
 
 abstract class PlatformPagecallView {
   Widget build({

--- a/lib/src/android_pagecallview.dart
+++ b/lib/src/android_pagecallview.dart
@@ -3,8 +3,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:pagecall_flutter/pagecall_flutter.dart';
-import 'package:pagecall_flutter/platform_interface.dart';
+import 'package:flutter_pagecall/flutter_pagecall.dart';
+import 'package:flutter_pagecall/platform_interface.dart';
 
 class AndroidPagecallView extends PlatformPagecallView {
   @override

--- a/lib/src/cupertino_pagecallview.dart
+++ b/lib/src/cupertino_pagecallview.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:pagecall_flutter/pagecall_flutter.dart';
-import 'package:pagecall_flutter/platform_interface.dart';
+import 'package:flutter_pagecall/flutter_pagecall.dart';
+import 'package:flutter_pagecall/platform_interface.dart';
 
 class CupertinoPagecallView extends PlatformPagecallView {
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
-name: pagecall_flutter
+name: flutter_pagecall
 description: Pagecall Flutter plugin
-version: 1.0.1
+version: 1.0.0
 homepage: https://www.pagecall.com
 repository: https://github.com/pagecall/flutter-pagecall
 
@@ -36,7 +36,7 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.pagecall.pagecall_flutter
+        package: com.pagecall.flutter_pagecall
         pluginClass: PagecallFlutterPlugin
       ios:
         pluginClass: PagecallFlutterPlugin


### PR DESCRIPTION
패키지 이름을 pagecall_flutter에서 flutter_pagecall로 바꿉니다.

AOS, iOS 둘 다 테스트 완료.
해당 PR 기준으로 이미 1.0.0 배포 완료되었습니다. https://pub.dev/packages/flutter_pagecall/versions/1.0.0