### PR TITLE
fix: update android sdk 0.0.21, handle keyDown for chime

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.pagecall:pagecall-android-sdk:0.0.19'
+        implementation 'com.pagecall:pagecall-android-sdk:0.0.21'
     }
 
     testOptions {

--- a/android/src/main/kotlin/com/pagecall/flutter_pagecall/FlutterPagecallView.kt
+++ b/android/src/main/kotlin/com/pagecall/flutter_pagecall/FlutterPagecallView.kt
@@ -3,6 +3,7 @@ package com.pagecall.flutter_pagecall
 import android.content.Context
 import android.net.Uri
 import android.os.Handler
+import android.view.KeyEvent
 import android.view.View
 import android.webkit.WebView
 import com.pagecall.PagecallWebView
@@ -34,7 +35,11 @@ class FlutterPagecallView(
     private var queryParams: String? = null
     private var debuggable: Boolean = false
 
+    companion object {
+        val instances = mutableListOf<FlutterPagecallView>()
+    }
     init {
+        instances.add(this)
         initParams(params)
 
         channel.setMethodCallHandler(this)
@@ -132,7 +137,11 @@ class FlutterPagecallView(
         }
     }
 
+    fun handleKeyDownEvent(keyCode: Int, event: KeyEvent?): Boolean {
+        return pagecallWebView.handleVolumeKeys(keyCode, event)
+    }
     override fun dispose() {
+        instances.remove(this)
         channel.setMethodCallHandler(null)
         pagecallWebView.destroy()
     }

--- a/example/android/app/src/main/kotlin/com/pagecall/pagecall_flutter_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/pagecall/pagecall_flutter_example/MainActivity.kt
@@ -1,6 +1,16 @@
 package com.pagecall.flutter_pagecall_example
 
+import android.view.KeyEvent
+import com.pagecall.flutter_pagecall.FlutterPagecallView
 import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity: FlutterActivity() {
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        for (instance in FlutterPagecallView.instances) {
+            if(instance.handleKeyDownEvent(keyCode, event)) {
+               return true
+            }
+        }
+        return super.onKeyDown(keyCode, event)
+    }
 }


### PR DESCRIPTION
# Changes

- 모든 활성 인스턴스를 추적하기 위해 FlutterPagecallView에 instances 리스트를 추가하였습니다.
- 키가 눌러질 때의 이벤트를 처리하기 위해 FlutterPagecallView에 handleKeyDownEvent 메소드를 추가하였습니다.
- 키가 눌러질 때마다 모든 활성화된 FlutterPagecallView 인스턴스에서 handleKeyDownEvent 메소드가 호출되도록 MainActivity를 수정하였습니다.

# Test

- Chime 일때는 미디어 볼륨이 조절되고, MI일때는 통화 볼륨이 조절되는 것을 확인했습니다.