### PR TITLE
Update to 1.0.2 (ios 0.0.18, android 0.0.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@
 ## 1.0.1
 * Update Android SDK (to 0.0.21)
 * handle volume key event for Chime usage
+
+## 1.0.2
+* Update Android SDK (to 0.0.25)
+* Update iOS SDK (to 0.0.18)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.pagecall:pagecall-android-sdk:0.0.21'
+        implementation 'com.pagecall:pagecall-android-sdk:0.0.25'
     }
 
     testOptions {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,13 +2,13 @@ PODS:
   - Flutter (1.0.0)
   - flutter_pagecall (0.0.1):
     - Flutter
-    - Pagecall (= 0.0.15)
+    - Pagecall (= 0.0.18)
   - fluttertoast (0.0.2):
     - Flutter
     - Toast
   - integration_test (0.0.1):
     - Flutter
-  - Pagecall (0.0.15)
+  - Pagecall (0.0.18)
   - Toast (4.0.0)
 
 DEPENDENCIES:
@@ -34,10 +34,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  flutter_pagecall: 0c5d2d31e54bee88c4798e81ad916a5349ff786e
+  flutter_pagecall: 543948c32d67d00db25188fbf2b5ec6066fdb263
   fluttertoast: fafc4fa4d01a6a9e4f772ecd190ffa525e9e2d9c
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  Pagecall: 3488f4fdbbd31e4730bf8ad0a829379a0b5c496f
+  Pagecall: 3a2d759ddcf0219709bdeced68e343037b8d5dfa
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
 PODFILE CHECKSUM: 1959d098c91d8a792531a723c4a9d7e9f6a01e38

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/ios/flutter_pagecall.podspec
+++ b/ios/flutter_pagecall.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Pagecall', '0.0.15'
+  s.dependency 'Pagecall', '0.0.18'
   s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_pagecall
 description: Pagecall Flutter plugin
-version: 1.0.1
+version: 1.0.2
 homepage: https://www.pagecall.com
 repository: https://github.com/pagecall/flutter-pagecall
 


### PR DESCRIPTION
Update to 1.0.2 (ios 0.0.18, android 0.0.25)

이미 배포됨 
https://pub.dev/packages/flutter_pagecall/versions/1.0.2 