### PR TITLE
Update to 1.0.8 (with iOS 0.0.26, Android 0.0.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,7 @@
 ## 1.0.7
 * Update Android SDK (to 0.0.43)
 * Update iOS SDK (to 0.0.24)
+
+## 1.0.8
+* Update Android SDK (to 0.0.45)
+* Update iOS SDK (to 0.0.26)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.pagecall:pagecall-android-sdk:0.0.43'
+        implementation 'com.pagecall:pagecall-android-sdk:0.0.45'
     }
 
     testOptions {

--- a/android/src/main/kotlin/com/pagecall/flutter_pagecall/FlutterPagecallView.kt
+++ b/android/src/main/kotlin/com/pagecall/flutter_pagecall/FlutterPagecallView.kt
@@ -9,6 +9,7 @@ import android.webkit.WebResourceError
 import android.webkit.WebView
 import com.pagecall.PagecallWebView
 import com.pagecall.TerminationReason
+import com.pagecall.PagecallError
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -72,7 +73,7 @@ class FlutterPagecallView(
                 }
             }
 
-            override fun onError(error: WebResourceError?) {
+            override fun onError(error: PagecallError?) {
                 Handler(context.mainLooper).post {
                     channel.invokeMethod("onError", error?.toString())
                 }

--- a/ios/flutter_pagecall.podspec
+++ b/ios/flutter_pagecall.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Pagecall', '0.0.24'
+  s.dependency 'Pagecall', '0.0.26'
   s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_pagecall
 description: Pagecall Flutter plugin
-version: 1.0.6
+version: 1.0.8
 homepage: https://www.pagecall.com
 repository: https://github.com/pagecall/flutter-pagecall
 


### PR DESCRIPTION
- iOS
  - https://github.com/pagecall/pagecall-ios-sdk/releases/tag/0.0.25
  - https://github.com/pagecall/pagecall-ios-sdk/releases/tag/0.0.26
- Android
  - https://github.com/pagecall/pagecall-android-sdk/releases/tag/0.0.44 (0.0.43 -> 0.0.44)
  - https://github.com/pagecall/pagecall-android-sdk/releases/tag/0.0.45